### PR TITLE
Change some fields into Options to work with cs2

### DIFF
--- a/src/payload/map.rs
+++ b/src/payload/map.rs
@@ -18,8 +18,8 @@ pub struct Map {
     /// Terrorists team info
     pub team_t: super::TeamInfo,
     pub num_matches_to_win_series: u8,
-    pub current_spectators: u8,
-    pub souvenirs_total: u8
+    pub current_spectators: Option<u8>,
+    pub souvenirs_total: Option<u8>
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]


### PR DESCRIPTION
CS2 slightly changed which fields are present in the requests.
This breaks the current implementation, because there are some fields missing.
By turning these fields into Options the implementation works again, but it will break current implementations.
This means it would need a SemVer bump.